### PR TITLE
Encode the client secret

### DIFF
--- a/Demos/01-rest-via-powershell/Get-CurrentUserProfile.ps1
+++ b/Demos/01-rest-via-powershell/Get-CurrentUserProfile.ps1
@@ -17,7 +17,7 @@
         )
 
         $clientID = $credential.Username
-        $clientSecret = $credential.GetNetworkCredential().Password
+        $clientSecret = [System.Web.HttpUtility]::UrlEncode("YourAppClientSecret")
 
         #v2.0 authorize URL
         $authorizeUrl = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"

--- a/Demos/01-rest-via-powershell/readme.md
+++ b/Demos/01-rest-via-powershell/readme.md
@@ -58,7 +58,7 @@ This demo will walk you through connecting to the Azure AD v2.0 endpoints to aut
         )
 
         $clientID = $credential.Username
-        $clientSecret = $credential.GetNetworkCredential().Password
+        $clientSecret = [System.Web.HttpUtility]::UrlEncode("YourAppClientSecret")
 
         #v2.0 authorize URL
         $authorizeUrl = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"


### PR DESCRIPTION
Encode the client secret to avoid the error "Invalid secret ID" when it contains special characters